### PR TITLE
Add shopping list page

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -25,6 +25,7 @@ import {
   BarChart as ChartIcon,
   Settings as SettingsIcon,
   Home as HomeIcon,
+  ShoppingCart as ShoppingCartIcon,
 } from '@mui/icons-material';
 import { motion } from 'framer-motion';
 
@@ -45,6 +46,7 @@ export default function Layout({ children }) {
     { text: 'Liste des travaux', icon: <ListIcon />, path: '/travaux' },
     { text: 'Agenda', icon: <CalendarIcon />, path: '/agenda' },
     { text: 'Rapport', icon: <ChartIcon />, path: '/rapport' },
+    { text: 'Liste de courses', icon: <ShoppingCartIcon />, path: '/courses' },
     { text: 'Gérer les tâches', icon: <SettingsIcon />, path: '/gestion' },
   ];
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -4,6 +4,7 @@ import { MongoClient } from 'mongodb';
 const uri = process.env.MONGODB_URI;
 const dbName = process.env.MONGODB_DB || 'planner_db';
 const collectionName = process.env.MONGODB_COLLECTION || 'tasks';
+const shoppingCollectionName = process.env.SHOPPING_COLLECTION || 'shopping';
 
 if (!uri) {
   throw new Error('Veuillez définir la variable d\'environnement MONGODB_URI');
@@ -31,6 +32,13 @@ export async function getTasksCollection() {
   const client = await clientPromise;
   const db = client.db(dbName);
   return db.collection(collectionName);
+}
+
+// Fonction pour obtenir la collection de la liste de courses
+export async function getShoppingCollection() {
+  const client = await clientPromise;
+  const db = client.db(dbName);
+  return db.collection(shoppingCollectionName);
 }
 
 export default clientPromise; 

--- a/lib/shoppingService.js
+++ b/lib/shoppingService.js
@@ -1,0 +1,42 @@
+import { getShoppingCollection } from './mongodb';
+
+let cache = null;
+let lastUpdate = null;
+const CACHE_DURATION = 30000; // 30s
+
+async function loadItems() {
+  const now = Date.now();
+  if (cache && lastUpdate && now - lastUpdate < CACHE_DURATION) {
+    return cache;
+  }
+  const collection = await getShoppingCollection();
+  const items = await collection.find().sort({ date: 1 }).toArray();
+  cache = items;
+  lastUpdate = now;
+  return items;
+}
+
+export async function getAllItems() {
+  return loadItems();
+}
+
+export async function addItem(item) {
+  const collection = await getShoppingCollection();
+  const result = await collection.insertOne(item);
+  if (result.acknowledged) {
+    cache = null;
+    return true;
+  }
+  return false;
+}
+
+export async function deleteItem(id) {
+  const collection = await getShoppingCollection();
+  const { ObjectId } = await import('mongodb');
+  const result = await collection.deleteOne({ _id: new ObjectId(id) });
+  if (result.deletedCount) {
+    cache = null;
+    return true;
+  }
+  return false;
+}

--- a/pages/api/shopping/[id].js
+++ b/pages/api/shopping/[id].js
@@ -1,0 +1,16 @@
+import { deleteItem } from '../../../lib/shoppingService';
+
+export default async function handler(req, res) {
+  const { method, query: { id } } = req;
+  if (method !== 'DELETE') {
+    res.setHeader('Allow', ['DELETE']);
+    return res.status(405).end();
+  }
+  try {
+    const success = await deleteItem(id);
+    if (success) return res.status(200).json({ success: true });
+    res.status(404).json({ error: 'Article non trouvé' });
+  } catch {
+    res.status(500).json({ error: 'Erreur lors de la suppression' });
+  }
+}

--- a/pages/api/shopping/index.js
+++ b/pages/api/shopping/index.js
@@ -1,0 +1,29 @@
+import { getAllItems, addItem } from '../../../lib/shoppingService';
+
+export default async function handler(req, res) {
+  const { method } = req;
+  if (method === 'GET') {
+    try {
+      const items = await getAllItems();
+      res.status(200).json(items);
+    } catch {
+      res.status(500).json({ error: 'Erreur lors de la récupération des articles' });
+    }
+  } else if (method === 'POST') {
+    try {
+      const item = req.body;
+      if (!item || !item.produit) {
+        return res.status(400).json({ error: 'Données invalides' });
+      }
+      item.date = item.date || new Date().toISOString();
+      const success = await addItem(item);
+      if (success) return res.status(201).json({ success: true });
+      res.status(400).json({ error: "Impossible d'ajouter" });
+    } catch (e) {
+      res.status(500).json({ error: 'Erreur lors de l\'ajout' });
+    }
+  } else {
+    res.setHeader('Allow', ['GET', 'POST']);
+    res.status(405).end();
+  }
+}

--- a/pages/courses.js
+++ b/pages/courses.js
@@ -1,0 +1,120 @@
+import { useState, useEffect } from 'react';
+import {
+  Typography,
+  Box,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  IconButton
+} from '@mui/material';
+import { Add as AddIcon, Delete as DeleteIcon } from '@mui/icons-material';
+import Layout from '../components/Layout';
+import dayjs from 'dayjs';
+
+export default function CoursesPage() {
+  const [items, setItems] = useState([]);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [newItem, setNewItem] = useState({ magasin: '', produit: '', lien: '', prix: '', date: dayjs().format('YYYY-MM-DD') });
+
+  const fetchItems = async () => {
+    try {
+      const res = await fetch('/api/shopping');
+      const data = await res.json();
+      setItems(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  useEffect(() => { fetchItems(); }, []);
+
+  const handleAdd = async () => {
+    if (!newItem.produit) return;
+    await fetch('/api/shopping', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(newItem)
+    });
+    setDialogOpen(false);
+    setNewItem({ magasin: '', produit: '', lien: '', prix: '', date: dayjs().format('YYYY-MM-DD') });
+    fetchItems();
+  };
+
+  const handleDelete = async (id) => {
+    await fetch(`/api/shopping/${id}`, { method: 'DELETE' });
+    fetchItems();
+  };
+
+  return (
+    <Layout>
+      <Box mb={4} display="flex" justifyContent="space-between" alignItems="center">
+        <div>
+          <Typography variant="h4" gutterBottom>Liste de courses</Typography>
+          <Typography variant="subtitle1" color="text.secondary">Ajoutez vos achats à venir</Typography>
+        </div>
+        <Button variant="contained" startIcon={<AddIcon />} onClick={() => setDialogOpen(true)}>Ajouter</Button>
+      </Box>
+
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Date</TableCell>
+              <TableCell>Magasin</TableCell>
+              <TableCell>Produit</TableCell>
+              <TableCell>Lien</TableCell>
+              <TableCell>Prix</TableCell>
+              <TableCell align="right">Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {items.map(item => (
+              <TableRow key={item._id}>
+                <TableCell>{dayjs(item.date).format('DD/MM/YYYY')}</TableCell>
+                <TableCell>{item.magasin}</TableCell>
+                <TableCell>{item.produit}</TableCell>
+                <TableCell>{item.lien && <a href={item.lien} target="_blank" rel="noopener noreferrer">Lien</a>}</TableCell>
+                <TableCell>{item.prix}</TableCell>
+                <TableCell align="right">
+                  <IconButton onClick={() => handleDelete(item._id)}>
+                    <DeleteIcon />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+            {items.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={6} align="center">Aucun article</TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle>Nouvel article</DialogTitle>
+        <DialogContent>
+          <TextField autoFocus margin="dense" label="Magasin" fullWidth value={newItem.magasin} onChange={e => setNewItem({ ...newItem, magasin: e.target.value })} />
+          <TextField margin="dense" label="Produit" fullWidth value={newItem.produit} onChange={e => setNewItem({ ...newItem, produit: e.target.value })} />
+          <TextField margin="dense" label="Lien" fullWidth value={newItem.lien} onChange={e => setNewItem({ ...newItem, lien: e.target.value })} />
+          <TextField margin="dense" label="Prix" fullWidth value={newItem.prix} onChange={e => setNewItem({ ...newItem, prix: e.target.value })} />
+          <TextField margin="dense" type="date" label="Date" InputLabelProps={{ shrink: true }} fullWidth value={newItem.date} onChange={e => setNewItem({ ...newItem, date: e.target.value })} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)}>Annuler</Button>
+          <Button variant="contained" onClick={handleAdd}>Ajouter</Button>
+        </DialogActions>
+      </Dialog>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add shopping list page with ability to add/delete items
- add API routes and service to store shopping items in MongoDB
- extend DB utilities with shopping collection
- show new navigation entry in layout

## Testing
- `npm run test-db` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6852cf04a028832281e347e606e9bc13