### PR TITLE
Add shared Material UI theme

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,70 +1,12 @@
 import { useState, useEffect } from 'react';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
+import theme from '../styles/theme';
 import CssBaseline from '@mui/material/CssBaseline';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import 'dayjs/locale/fr';
 import '../styles/globals.css';
 
-// Création d'un thème personnalisé
-const theme = createTheme({
-  palette: {
-    primary: {
-      main: '#1E88E5', // Bleu principal
-    },
-    secondary: {
-      main: '#4CAF50', // Vert
-    },
-    error: {
-      main: '#F44336', // Rouge pour les statuts "À faire"
-    },
-    warning: {
-      main: '#FF9800', // Orange pour les statuts "En cours"
-    },
-    info: {
-      main: '#2196F3', // Bleu pour les priorités
-    },
-    success: {
-      main: '#4CAF50', // Vert pour les statuts "Terminé"
-    },
-    background: {
-      default: '#f5f5f5',
-    },
-  },
-  typography: {
-    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
-    h1: {
-      fontSize: '2.2rem',
-      fontWeight: 500,
-    },
-    h2: {
-      fontSize: '1.8rem',
-      fontWeight: 500,
-    },
-    h3: {
-      fontSize: '1.5rem',
-      fontWeight: 500,
-    }
-  },
-  components: {
-    MuiCard: {
-      styleOverrides: {
-        root: {
-          borderRadius: 8,
-          boxShadow: '0 2px 10px rgba(0,0,0,0.08)',
-        },
-      },
-    },
-    MuiButton: {
-      styleOverrides: {
-        root: {
-          borderRadius: 8,
-          textTransform: 'none',
-        },
-      },
-    },
-  },
-});
 
 function MyApp({ Component, pageProps }) {
   // État pour vérifier si l'app est prête côté client
@@ -89,4 +31,4 @@ function MyApp({ Component, pageProps }) {
   );
 }
 
-export default MyApp; 
+export default MyApp;

--- a/styles/theme.js
+++ b/styles/theme.js
@@ -1,0 +1,64 @@
+import { createTheme } from '@mui/material/styles';
+
+const palette = {
+  primary: {
+    main: '#1E88E5',
+  },
+  secondary: {
+    main: '#4CAF50',
+  },
+  error: {
+    main: '#F44336',
+  },
+  warning: {
+    main: '#FF9800',
+  },
+  info: {
+    main: '#2196F3',
+  },
+  success: {
+    main: '#4CAF50',
+  },
+  background: {
+    default: '#f5f5f5',
+  },
+};
+
+const typography = {
+  fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+  h1: {
+    fontSize: '2.2rem',
+    fontWeight: 500,
+  },
+  h2: {
+    fontSize: '1.8rem',
+    fontWeight: 500,
+  },
+  h3: {
+    fontSize: '1.5rem',
+    fontWeight: 500,
+  },
+};
+
+const components = {
+  MuiCard: {
+    styleOverrides: {
+      root: {
+        borderRadius: 8,
+        boxShadow: '0 2px 10px rgba(0,0,0,0.08)',
+      },
+    },
+  },
+  MuiButton: {
+    styleOverrides: {
+      root: {
+        borderRadius: 8,
+        textTransform: 'none',
+      },
+    },
+  },
+};
+
+const theme = createTheme({ palette, typography, components });
+
+export default theme;


### PR DESCRIPTION
## Summary
- centralize Material UI theme configuration in `styles/theme.js`
- use the shared theme in `_app.js`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852db2d80508322bb711ff5abedb979